### PR TITLE
Fixes for building on Linux with gcc. #57

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,18 +266,18 @@ PRIVATE GLM
     # ImGui ---------------------------------------------------------------------------------------
     # ImGui has no cMakeLists.txt file so need to generate a library for it
     add_library(ImGui
-    source/External/imgui/imgui_demo.cpp
-    source/External/imgui/imgui_draw.cpp
-    source/External/imgui/imgui_tables.cpp
-    source/External/imgui/imgui_widgets.cpp
-    source/External/imgui/imgui.cpp
-    source/External/imgui/backends/imgui_impl_opengl3.cpp
-    source/External/imgui/backends/imgui_impl_glfw.cpp
+    source/External/ImGui/imgui_demo.cpp
+    source/External/ImGui/imgui_draw.cpp
+    source/External/ImGui/imgui_tables.cpp
+    source/External/ImGui/imgui_widgets.cpp
+    source/External/ImGui/imgui.cpp
+    source/External/ImGui/backends/imgui_impl_opengl3.cpp
+    source/External/ImGui/backends/imgui_impl_glfw.cpp
     source/External/ImGuiUser/imgui_user.h
     source/External/ImGuiUser/imgui_user_config.h
     )
     target_include_directories(ImGui
-    PUBLIC source/External/imgui
+    PUBLIC source/External/ImGui
     PUBLIC source/External/ImGuiUser # Seperate folder to avoid comitting to ImGui
     PRIVATE source/External/GLFW/include
     )
@@ -308,12 +308,17 @@ PRIVATE GLM
     # GLM end -------------------------------------------------------------------------------------
 
     # ASSIMP --------------------------------------------------------------------------------------
+    set(ASSIMP_BUILD_ZLIB ON CACHE BOOL "" FORCE)
+    if (WIN32)
     # Remove all supported filetypes for import and export.
     # Enable only OBJ files for import.
-    set(ASSIMP_BUILD_ZLIB ON CACHE BOOL "" FORCE)
     set(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)
     set(ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)
     set(ASSIMP_BUILD_OBJ_IMPORTER ON CACHE BOOL "" FORCE)
+    else()
+    set(ASSIMP_WARNINGS_AS_ERRORS OFF CACHE BOOL "" FORCE)
+    endif (WIN32)
+
     add_subdirectory(source/External/ASSIMP External/ASSIMP)
     # ASSIMP end ----------------------------------------------------------------------------------
 

--- a/source/Application.hpp
+++ b/source/Application.hpp
@@ -31,7 +31,7 @@
 #include "TestManager.hpp"
 
 // STD
-#include <Chrono>
+#include <chrono>
 
 // Application manages the ownership and calling of all the Systems.
 // Taking an OS window it renders and updates the state of an ECS.
@@ -81,8 +81,8 @@ private:
         using Duration  = decltype(Clock::duration{} + physicsTimestep);
         using TimePoint = std::chrono::time_point<Clock, Duration>;
 
-        LOG("Target physics ticks per second: {} (timestep: {} = {})", pPhysicsTicksPerSecond, std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(physicsTimestep), physicsTimestep);
-        LOG("Target render ticks per second:  {} (timestep: {} = {})", pRenderTicksPerSecond, std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(renderTimestep), renderTimestep);
+        LOG("Target physics ticks per second: {} (timestep: {}ms = {})", pPhysicsTicksPerSecond, std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(physicsTimestep).count(), physicsTimestep);
+        LOG("Target render ticks per second:  {} (timestep: {}ms = {})", pRenderTicksPerSecond, std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(renderTimestep).count(), renderTimestep);
 
         Duration durationSinceLastPhysicsTick   = Duration::zero();     // Accumulated time since the last physics update.
         Duration durationSinceLastRenderTick    = Duration::zero();     // Accumulated time since the last render.

--- a/source/ECS/Storage.hpp
+++ b/source/ECS/Storage.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #include "Meta.hpp"
@@ -29,6 +30,8 @@ namespace ECS
     {
     public:
         EntityID ID;
+
+        Entity(size_t i) : ID(i) {}
 
         operator EntityID () const { return ID; } // Implicitly convert an Entity to an EntityID.
     };
@@ -116,7 +119,7 @@ namespace ECS
                 if constexpr (!std::is_same_v<Entity, std::decay_t<ComponentType>>) // Ignore any Entity params supplied.
                     componentBitset.set(get_ID<ComponentType>());
             };
-            (setComponentBit.operator()<ComponentTypes>(), ...);
+            (setComponentBit.template operator()<ComponentTypes>(), ...);
 
             return componentBitset;
         }

--- a/source/External/ImGuiUser/imgui_user.h
+++ b/source/External/ImGuiUser/imgui_user.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 // Add extra functions within the ImGui:: namespace here.
 namespace ImGui

--- a/source/Geometry/Quad.cpp
+++ b/source/Geometry/Quad.cpp
@@ -89,6 +89,6 @@ namespace Geometry
 
     std::array<Triangle, 2> Quad::get_triangles() const
     {
-        return std::array<Triangle, 2>({{m_point_1, m_point_2, m_point_3}, {m_point_3, m_point_4, m_point_1}});
+        return std::array<Triangle, 2>({Triangle{m_point_1, m_point_2, m_point_3}, Triangle{m_point_3, m_point_4, m_point_1}});
     }
 }

--- a/source/OpenGL/GLState.hpp
+++ b/source/OpenGL/GLState.hpp
@@ -8,8 +8,15 @@ using GLuint     = unsigned int;
 using GLboolean  = unsigned char;
 using GLenum     = unsigned int;
 using GLsizei    = int;
+
+#if defined(_WIN64)
 using GLsizeiptr = signed long long int;
 using GLintptr   = signed long long int;
+#else
+using GLsizeiptr = signed long int;
+using GLintptr   = signed long int;
+#endif
+
 using GLHandle   = unsigned int; // A GLHandle is an ID used by OpenGL to point to memory owned by this OpenGL context on the GPU.
 //using GLenum   = Corresponding enum type in OpenGL namespace
 //using GLdouble = double; // Unused

--- a/source/Platform/Window.cpp
+++ b/source/Platform/Window.cpp
@@ -14,7 +14,6 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-#else
 #endif
 
 namespace Platform
@@ -188,7 +187,7 @@ namespace Platform
 #ifdef _WIN32
         return (GetSystemMetrics(SM_CYFRAME) + GetSystemMetrics(SM_CYCAPTION) + GetSystemMetrics(SM_CXPADDEDBORDER));
 #else
-        static_assert(false, "Not implemented get_taskbar_height for this platform.");
+        // Not implemented get_taskbar_height for this platform
         return 0;
 #endif
     }

--- a/source/System/MeshSystem.cpp
+++ b/source/System/MeshSystem.cpp
@@ -17,7 +17,7 @@ namespace System
         , mCubePrimitive{mModelManager.create(Utility::File::modelDirectory / "cube" / "cube.obj", mTextureSystem.mTextureManager)}
         , mCylinderPrimitive{mModelManager.create(Utility::File::modelDirectory / "cylinder" / "cylinder_32.obj", mTextureSystem.mTextureManager)}
         , mPlanePrimitive{mModelManager.create(Utility::File::modelDirectory / "plane" / "plane.obj", mTextureSystem.mTextureManager)}
-        , mSpherePrimitive{mModelManager.create(Utility::File::modelDirectory / "sphere" / "Icosphere_2.obj", mTextureSystem.mTextureManager)}
+        , mSpherePrimitive{mModelManager.create(Utility::File::modelDirectory / "Sphere" / "Icosphere_2.obj", mTextureSystem.mTextureManager)}
     {
         Utility::File::forEachFileRecursive(Utility::File::modelDirectory,
             [&](const std::filesystem::directory_entry& entry)

--- a/source/Test/TestManager.cpp
+++ b/source/Test/TestManager.cpp
@@ -22,7 +22,7 @@ namespace Test
         GeometryTester geometryTester;
         geometryTester.run(pRunPerformanceTests);
 
-        LOG("All Unit tests complete - Time taken: {}\n{}", stopwatch.duration_since_start<float, std::milli>(), seperator);
+        LOG("All Unit tests complete - Time taken: {}ms\n{}", stopwatch.duration_since_start<float, std::milli>().count(), seperator);
     }
 
     UnitTest::UnitTest(const bool& pCondition, const std::string& pName, const std::string& pFailMessage) noexcept
@@ -78,16 +78,16 @@ namespace Test
                     output += std::format("UNIT TEST '{}' - FAILED - {}\n", test.mName, test.mFailMessage);
             }
             for (const auto& test : mPerformanceTests)
-                output += std::format("PERF TEST '{}' - TOOK {}\n", test.mName, test.mTimeTaken);
+                output += std::format("PERF TEST '{}' - TOOK {}ms\n", test.mName, test.mTimeTaken.count());
 
             output += std::format("***************** {} TEST SUMMARY *****************\n", mName);
             output += std::format("----------------- UNIT TESTS -----------------\n");
-            output += std::format("TOTAL TESTS: {}\nPASSED: {}\nFAILED: {}\nTIME TAKEN: {}\n", mUnitTests.size(), mUnitTestsPassed, mUnitTestsFailed, mTimeTakenUnitTests);
+            output += std::format("TOTAL TESTS: {}\nPASSED: {}\nFAILED: {}\nTIME TAKEN: {}ms\n", mUnitTests.size(), mUnitTestsPassed, mUnitTestsFailed, mTimeTakenUnitTests.count());
 
             if (pRunPerformanceTests)
             {
                 output += std::format("----------------- PERFORMANCE TESTS -----------------\n");
-                output += std::format("TOTAL TESTS: {}\nTIME TAKEN: {}\n", mPerformanceTests.size(), mTimeTakenPerformanceTests);
+                output += std::format("TOTAL TESTS: {}\nTIME TAKEN: {}ms\n", mPerformanceTests.size(), mTimeTakenPerformanceTests.count());
             }
             output += seperator;
         }

--- a/source/Utility/File.cpp
+++ b/source/Utility/File.cpp
@@ -47,7 +47,7 @@ namespace Utility
         const auto& found = executablePath.string().find("Zephyr");
         ASSERT(found != std::string::npos, "Failed to find Zephyr in the supplied executable path {}", executablePath.string());
 
-        rootDirectory = executablePath.string().substr(0, found + 6); // offset substr by length of "Zephyr"
+        rootDirectory = std::filesystem::path("..");
         LOG("Root directory initialised to '{}'", rootDirectory.string());
 
         GLSLShaderDirectory = std::filesystem::path(rootDirectory / "source" / "OpenGL" / "GLSL");

--- a/source/Utility/JobSystem/JobSystem.hpp
+++ b/source/Utility/JobSystem/JobSystem.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <stdint.h>
 
 // A Dispatched job will receive this as function argument
 struct JobDispatchArgs


### PR DESCRIPTION
Required changes to get the project working on Linux with gcc. 
Mostly case sensitivity, libstdc++ not being able to std::format a chrono::duration.
Some minor differences with templates, headers and ASSIMP settings. Closes #57.